### PR TITLE
Fix PSR-4 namespace for dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,9 @@
         }
     },
     "autoload-dev": {
-        "NickBeen\\NintendoConverter\\Tests\\": "tests"
+        "psr-4": {
+            "NickBeen\\NintendoConverter\\Tests\\": "tests"
+        }
     },
     "scripts": {
         "test": "vendor/bin/phpunit"


### PR DESCRIPTION
## What does this pull request do?

Fix ability to run tests.

## Why is this pull request needed?

Unable to run tests due to incorrect namespace statement for developer dependencies in `composer.json`. A bug in the IDE seemed to have allowed this error to slip through.
