### PR TITLE
Implement NegativeNumberException and deprecate InvalidArgumentException

### DIFF
--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -4,6 +4,9 @@ namespace NickBeen\NintendoConverter\Exceptions;
 
 use Exception;
 
+/**
+ * @deprecated since 1.2.0, use NegativeNumberException instead
+ */
 class InvalidArgumentException extends Exception
 {
     public $message = 'Cannot use a negative number.';

--- a/src/Exceptions/NegativeNumberException.php
+++ b/src/Exceptions/NegativeNumberException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace NickBeen\NintendoConverter\Exceptions;
+
+use Exception;
+
+class NegativeNumberException extends Exception
+{
+    public $message = 'Negative numbers are not allowed.';
+}

--- a/src/NintendoConverter.php
+++ b/src/NintendoConverter.php
@@ -3,7 +3,10 @@
 namespace NickBeen\NintendoConverter;
 
 use NickBeen\NintendoConverter\Exceptions\InvalidArgumentException;
+use NickBeen\NintendoConverter\Exceptions\NegativeNumberException;
 use NickBeen\NintendoConverter\Exceptions\UnnecessaryCalculation;
+
+class_alias(NegativeNumberException::class, InvalidArgumentException::class);
 
 class NintendoConverter
 {
@@ -43,7 +46,7 @@ class NintendoConverter
     /**
      * Convert Nintendo blocks to number of Megabytes
      *
-     * @throws InvalidArgumentException
+     * @throws NegativeNumberException
      * @throws UnnecessaryCalculation
      */
     public function toMegabytes(): int|float
@@ -53,7 +56,7 @@ class NintendoConverter
         }
 
         if ($this->blocks < 0) {
-            throw new InvalidArgumentException();
+            throw new NegativeNumberException();
         }
 
         return $this->blocks / pow(2, 3);
@@ -62,7 +65,7 @@ class NintendoConverter
     /**
      * Convert number of Megabytes to Nintendo blocks
      *
-     * @throws InvalidArgumentException
+     * @throws NegativeNumberException
      * @throws UnnecessaryCalculation
      */
     public function toBlocks(): int|float
@@ -72,7 +75,7 @@ class NintendoConverter
         }
 
         if ($this->bytes < 0) {
-            throw new InvalidArgumentException();
+            throw new NegativeNumberException();
         }
 
         return $this->bytes / pow(2, 17);

--- a/tests/NintendoConverterTest.php
+++ b/tests/NintendoConverterTest.php
@@ -2,7 +2,7 @@
 
 namespace NickBeen\NintendoConverter\Tests;
 
-use NickBeen\NintendoConverter\Exceptions\InvalidArgumentException;
+use NickBeen\NintendoConverter\Exceptions\NegativeNumberException;
 use NickBeen\NintendoConverter\Exceptions\UnnecessaryCalculation;
 use NickBeen\NintendoConverter\NintendoConverter;
 use PHPUnit\Framework\TestCase;
@@ -11,7 +11,8 @@ class NintendoConverterTest extends TestCase
 {
     /**
      * @test
-     * @throws UnnecessaryCalculation|InvalidArgumentException
+     * @throws NegativeNumberException
+     * @throws UnnecessaryCalculation
      */
     public function it_can_convert_blocks_to_megabytes()
     {
@@ -23,7 +24,8 @@ class NintendoConverterTest extends TestCase
 
     /**
      * @test
-     * @throws UnnecessaryCalculation|InvalidArgumentException
+     * @throws NegativeNumberException
+     * @throws UnnecessaryCalculation
      */
     public function it_can_convert_megabytes_to_blocks()
     {
@@ -35,7 +37,8 @@ class NintendoConverterTest extends TestCase
 
     /**
      * @test
-     * @throws UnnecessaryCalculation|InvalidArgumentException
+     * @throws NegativeNumberException
+     * @throws UnnecessaryCalculation
      */
     public function it_cannot_convert_blocks_to_blocks()
     {
@@ -49,7 +52,8 @@ class NintendoConverterTest extends TestCase
 
     /**
      * @test
-     * @throws UnnecessaryCalculation|InvalidArgumentException
+     * @throws NegativeNumberException
+     * @throws UnnecessaryCalculation
      */
     public function it_cannot_convert_megabytes_to_megabytes()
     {
@@ -63,11 +67,12 @@ class NintendoConverterTest extends TestCase
 
     /**
      * @test
-     * @throws UnnecessaryCalculation|InvalidArgumentException
+     * @throws NegativeNumberException
+     * @throws UnnecessaryCalculation
      */
     public function it_cannot_convert_negative_number_of_blocks()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(NegativeNumberException::class);
 
         $blocks = new NintendoConverter(blocks: -8);
         $megabytes = $blocks->toMegabytes();
@@ -77,11 +82,12 @@ class NintendoConverterTest extends TestCase
 
     /**
      * @test
-     * @throws UnnecessaryCalculation|InvalidArgumentException
+     * @throws NegativeNumberException
+     * @throws UnnecessaryCalculation
      */
     public function it_cannot_convert_negative_number_of_megabytes()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(NegativeNumberException::class);
 
         $megabytes = new NintendoConverter(megabytes: -1);
         $blocks = $megabytes->toBlocks();


### PR DESCRIPTION
## What does this pull request do?

This PR implements a more clear `NegativeNumberException` and deprecates the custom `InvalidArgumentException`.

## Why is this pull request needed?

`InvalidArgumentException` is a standard PHP exception and using a custom exception with the same name might cause confusion. `NegativeNumberException` is also a more accurate name for the thrown exception.
